### PR TITLE
FIX: reliable method for changing origin host

### DIFF
--- a/gram/gram.py
+++ b/gram/gram.py
@@ -124,9 +124,16 @@ def set_repo_user(username) -> None:
     parser = configparser.ConfigParser()
     parser.read(GIT_CONFIG)
 
-    # EX: git@github.com:SlimeMaid/slimemaid.github.io.git
+    # Use a custom host that corresponds with the
+    # host specified in SSH config. It may look like this:
+    # url = git@github.com:lily-mayfield/gram.git
+    # Simply replace what's between @ and :.
     old_url = parser['remote "origin"']['url']
-    new_url = old_url.replace('.com', '-' + username, 1)
+    new_url = (
+        old_url[:old_url.index('@') + 1]
+        + "github-" + username +
+        old_url[old_url.index(':'):]
+    )
     parser.set('remote "origin"', 'url', new_url)
 
     # Set user info too


### PR DESCRIPTION
Fix an error which occurs most notably when you
attempt to `gram assign` one user, and then try to
`gram assign` again but to another user: gram
previously did a find-replace for ".com", so once
gram already changed the origin host to
"github-username" there's no longer a .com and no
longer the ability to change the origin based on
the old method. The new method implemented (the
change) simply changes the git config origin host
value between @ and : which we know can always
blindly be updated to `github-someuser`.

Fixes #1 